### PR TITLE
Fixes callvalue non-payable error

### DIFF
--- a/stop.sol
+++ b/stop.sol
@@ -27,10 +27,10 @@ contract DSStop is DSNote, DSAuth {
         require(!stopped, "ds-stop-is-stopped");
         _;
     }
-    function stop() public auth note {
+    function stop() payable public auth note {
         stopped = true;
     }
-    function start() public auth note {
+    function start() payable public auth note {
         stopped = false;
     }
 


### PR DESCRIPTION
This change is need in order to be able to compile the contracts with solc 0.5.7. The compiler now raises an error if `callvalue` is used in a non-payable function.

Please see the original issue for futher information: https://github.com/ethereum/solidity/issues/6146 